### PR TITLE
Feature/nex 126/vendorize item runner scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # tao-item-runner
 
-TAO Item runner
-
 Item runner of TAO.
 
 Available scripts in the project:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -129,11 +129,10 @@
             "dev": true
         },
         "async": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-            "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-            "dev": true,
-            "optional": true
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+            "dev": true
         },
         "async-limiter": {
             "version": "1.0.0",
@@ -178,6 +177,17 @@
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "chardet": {
@@ -220,12 +230,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
             "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-            "dev": true
-        },
-        "commander": {
-            "version": "2.12.2",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-            "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
             "dev": true
         },
         "comment-parser": {
@@ -278,9 +282,9 @@
             }
         },
         "debug": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
             "dev": true,
             "requires": {
                 "ms": "^2.1.1"
@@ -311,14 +315,6 @@
                 "mime": "^1.6.0",
                 "minimist": "^1.1.0",
                 "url-join": "^2.0.5"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                }
             }
         },
         "emoji-regex": {
@@ -392,6 +388,15 @@
                 "text-table": "^0.2.0"
             },
             "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
                 "lodash": {
                     "version": "4.17.11",
                     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
@@ -613,17 +618,6 @@
             "dev": true,
             "requires": {
                 "debug": "^3.2.6"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                }
             }
         },
         "fs.realpath": {
@@ -666,6 +660,17 @@
             "requires": {
                 "optimist": "~0.3",
                 "uglify-js": "~2.3"
+            },
+            "dependencies": {
+                "optimist": {
+                    "version": "0.3.7",
+                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                    "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+                    "dev": true,
+                    "requires": {
+                        "wordwrap": "~0.0.2"
+                    }
+                }
             }
         },
         "has-flag": {
@@ -705,24 +710,6 @@
                 "optimist": "0.6.x",
                 "portfinder": "^1.0.13",
                 "union": "~0.4.3"
-            },
-            "dependencies": {
-                "optimist": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                    "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "~0.0.1",
-                        "wordwrap": "~0.0.2"
-                    }
-                },
-                "wordwrap": {
-                    "version": "0.0.3",
-                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-                    "dev": true
-                }
             }
         },
         "https-proxy-agent": {
@@ -733,17 +720,6 @@
             "requires": {
                 "agent-base": "^4.1.0",
                 "debug": "^3.1.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                }
             }
         },
         "iconv-lite": {
@@ -951,9 +927,9 @@
             }
         },
         "minimist": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
             "dev": true
         },
         "mkdirp": {
@@ -963,6 +939,14 @@
             "dev": true,
             "requires": {
                 "minimist": "0.0.8"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                }
             }
         },
         "moment": {
@@ -1044,18 +1028,19 @@
             "dev": true
         },
         "optimist": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-            "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
+                "minimist": "~0.0.1",
                 "wordwrap": "~0.0.2"
             },
             "dependencies": {
-                "wordwrap": {
-                    "version": "0.0.3",
-                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                "minimist": {
+                    "version": "0.0.10",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                    "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
                     "dev": true
                 }
             }
@@ -1072,6 +1057,14 @@
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2",
                 "wordwrap": "~1.0.0"
+            },
+            "dependencies": {
+                "wordwrap": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+                    "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+                    "dev": true
+                }
             }
         },
         "os-tmpdir": {
@@ -1130,12 +1123,6 @@
                 "mkdirp": "0.5.x"
             },
             "dependencies": {
-                "async": {
-                    "version": "1.5.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-                    "dev": true
-                },
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1205,6 +1192,15 @@
                 "ws": "^6.1.0"
             },
             "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
                 "mime": {
                     "version": "2.4.4",
                     "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
@@ -1230,6 +1226,23 @@
                 "minimatch": "3.0.4",
                 "node-watch": "0.6.0",
                 "resolve": "1.9.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.12.2",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+                    "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+                    "dev": true
+                },
+                "resolve": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+                    "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                }
             }
         },
         "readable-stream": {
@@ -1264,15 +1277,6 @@
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
             "dev": true
-        },
-        "resolve": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
-            "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
-            "dev": true,
-            "requires": {
-                "path-parse": "^1.0.6"
-            }
         },
         "resolve-from": {
             "version": "4.0.0",
@@ -1393,16 +1397,6 @@
                 "is-fullwidth-code-point": "^2.0.0"
             }
         },
-        "source-map": {
-            "version": "0.1.43",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-            "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "amdefine": ">=0.0.4"
-            }
-        },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -1442,15 +1436,6 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
             "dev": true
-        },
-        "supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "requires": {
-                "has-flag": "^3.0.0"
-            }
         },
         "table": {
             "version": "5.4.0",
@@ -1550,6 +1535,35 @@
                 "async": "~0.2.6",
                 "optimist": "~0.3.5",
                 "source-map": "~0.1.7"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "0.2.10",
+                    "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                    "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                    "dev": true,
+                    "optional": true
+                },
+                "optimist": {
+                    "version": "0.3.7",
+                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                    "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "wordwrap": "~0.0.2"
+                    }
+                },
+                "source-map": {
+                    "version": "0.1.43",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                    "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "amdefine": ">=0.0.4"
+                    }
+                }
             }
         },
         "union": {
@@ -1598,9 +1612,9 @@
             }
         },
         "wordwrap": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
             "dev": true
         },
         "wrappy": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "displayName": "TAO Item Runner",
     "files": [
         "dist",

--- a/src/scoring/api/scorer.js
+++ b/src/scoring/api/scorer.js
@@ -1,0 +1,164 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2014-2019 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+/**
+ * The TAO scoring library API,
+ * A
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+import _ from 'lodash';
+import eventifier from 'core/eventifier';
+
+
+/**
+ *
+ * Builds a brand new {@link Scorer}.
+ *
+ * <strong>The factory is an internal mechanism to create encapsulated contexts.
+ *  I suggest you to use directly the name <i>scorer</i> when you require this module.</strong>
+ *
+ * @example require(['scorer'], function(scorer){
+ *      scorer(options)
+ *          .on('error', function(err){
+ *
+ *          })
+ *          .on('outcome', function(outcome){
+ *
+ *          })
+ *          .process(responses, responseProcessing);
+ *  });
+ *
+ * @exports scorer
+ * @namespace scorerFactory
+ *
+ * @param {String} [providerName] - the name of a provider previously registered see {@link scorerFactory#register}
+ * @param {Object} [options] - scorer options
+ *
+ * @returns {Scorer}
+ */
+var scorerFactory = function scorerFactory(providerName, options) {
+    var provider;
+    var providers;
+
+    //optional params based on type
+    if (_.isPlainObject(providerName)) {
+        options = providerName;
+        providerName = undefined;
+    }
+    options = options || {};
+
+    /*
+     * Select the provider
+     */
+    providers = scorerFactory.providers;
+
+    //check a provider is available
+    if (!providers || _.size(providers) === 0) {
+        throw new Error('No provider regitered');
+    }
+
+    if (_.isString(providerName) && providerName.length > 0) {
+        provider = providers[providerName];
+    } else if (_.size(providers) === 1) {
+
+        //if there is only one provider, then we take this one
+        providerName = _.keys(providers)[0];
+        provider = providers[providerName];
+    }
+
+    //now we should have a provider
+    if (!provider) {
+        throw new Error('No candidate found for the provider');
+    }
+
+
+    /**
+     * The Scorer
+     * @typedef {Object} scorer
+     */
+
+    /**
+     * @type {scorer}
+     * @lends scorerFactory
+     * @augments core/eventifier
+     */
+    return eventifier({
+
+        /**
+         * Process the response
+         * @param {Object[]} responses - the responses to score
+         * @param {Object} processingData - all the data needed to grade/process the response
+         * @fires Scorer#outcome
+         * @fires Scorer#error
+         */
+        process: function process(responses, processingData) {
+            var self = this;
+            if (_.isFunction(provider.process)) {
+
+                /**
+                 * Calls the provider's process
+                 * @callback ProcessScoringProvider
+                 * @param {Object[]} responses - the responses to score
+                 * @param {Object} processingData - all the data needed to grade/process the response
+                 * @param {Function} done - call once the render is done
+                 */
+                provider.process.call(this, responses, processingData, function proceed(outcome, state) {
+                    if (!_.isPlainObject(outcome)) {
+                        return self.trigger('error', `The given outcome is not formated correctly. An object is expected but a ${typeof outcome} given`);
+                    }
+
+                    /**
+                     * Outcomes are produced
+                     * @param {Object} outcome - outcome variables
+                     * @param {Object} state - the scoring state
+                     */
+                    self.trigger('outcome', outcome, state);
+                });
+            }
+        }
+    });
+};
+
+/**
+ * Register an <i>Scoring Provider</i> into the scorer.
+ * The provider provides the behavior required by the scorer.
+ *
+ * @param {String} name - the provider name will be used to select the provider.
+ *
+ * @param {Object} provider - the Scoring Provier as a plain object. The scorer forwards encapsulate and delegate calls to the provider.
+ * @param {ProcessScoringProvider} provider.process - how to process the responses to create an outcome
+ *
+ * @throws TypeError when a wrong provider is given or an empty name.
+ */
+scorerFactory.register = function registerProvider(name, provider) {
+    //type checking
+    if (!_.isString(name) || name.length <= 0) {
+        throw new TypeError('It is required to give a name to your provider.');
+    }
+    if (!_.isPlainObject(provider) || !_.isFunction(provider.process)) {
+        throw new TypeError('A provider is an object that contains a process function.');
+    }
+
+    this.providers = this.providers || {};
+    this.providers[name] = provider;
+};
+
+export default scorerFactory;
+


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/NEX-126

This part of the Item Runner vendorization just adds one JS file (the scoring API).
There were no associated tests to include.
It's depended on only by parts of the QTI scoring implementation in tao-item-runner-qti-fe

Basic testing of this can be done as a standalone package by running `npm i && npm run build`
The output will be created in `dist`.

The integration of the package back into TAO comes as a future task, but when testing the related PR (https://github.com/oat-sa/tao-item-runner-qti-fe/pull/2) you can check that the built files are resolved.