### PR TITLE
add getApipData to itemRunner

### DIFF
--- a/.qunit-testrunner.config.json
+++ b/.qunit-testrunner.config.json
@@ -1,4 +1,7 @@
 {
-    "verbose": 2,
-    "coverage-instrument-spec": ""
+  "verbose": 4,
+  "testDir": "test",
+  "coverage": true,
+  "coverage-instrument-spec": "",
+  "port": 8082
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
     "name": "@oat-sa/tao-item-runner",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "displayName": "TAO Item Runner",
     "description": "TAO Item Runner modules",
+
     "files": [
         "dist",
         "src"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "version": "0.4.0",
     "displayName": "TAO Item Runner",
     "description": "TAO Item Runner modules",
-
     "files": [
         "dist",
         "src"

--- a/src/runner/README.md
+++ b/src/runner/README.md
@@ -49,6 +49,7 @@ It works in 2 steps:
 |    setState(Object state) : ItemRunner        +------------------->  setState(Object state) : void              |
 |    getResponses() : Array                     +------------------->  getResponses() : Array                     |
 |    clear() : ItemRunner                       +------------------->  clear() : void                             |
+|    getApipData() : Object                     +------------------->  getApipData() : Object                     |
 |                                                  |               |                                              |
 |    on(event,Func handler) : ItemRunner           |               |                                              |
 |    off(event) : ItemRunner                       |               |                                              |

--- a/src/runner/api/itemRunner.js
+++ b/src/runner/api/itemRunner.js
@@ -427,6 +427,19 @@ var itemRunnerFactory = function itemRunnerFactory(providerName, data, options) 
             if (_.isFunction(provider.renderFeedbacks)) {
                 provider.renderFeedbacks.call(this, feedbacks, itemSession, done);
             }
+        },
+
+        /**
+         * Provide access the data about APIP the content and related media files
+         *
+         * @returns {Object} the item's APIP data section
+         */
+        getApipData: function getApipData() {
+            var apipData = {};
+            if (_.isFunction(provider.renderFeedbacks)) {
+                apipData = provider.getApipData.call(this);
+            }
+            return apipData;
         }
     });
 };

--- a/test/runner/api/test.js
+++ b/test/runner/api/test.js
@@ -739,4 +739,30 @@ define(['jquery', 'lodash', 'taoItems/runner/api/itemRunner', 'test/taoItems/run
             .init()
             .render($container);
     });
+
+
+    QUnit.test('getApipData', function(assert) {
+        assert.expect(1);
+
+        $container = $('#item-container');
+        assert.equal($container.length, 1, 'the item container exists');
+
+        itemRunner.register('dummyProvider', dummyProvider);
+
+        itemRunner('dummyProvider', {
+            type: 'number',
+            value: 0
+        })
+            .on('render', function() {
+                this.renderFeedbacks({"f":'f'}, ["f"], function(renderingQueue) {
+                    var apipData = itemRunner.getApipData();
+                    var apipDataIsApplicable = _.isNull(apipData) || _.isPlainObject(apipData);
+                    assert.ok(apipDataIsApplicable, 'getApipData returns a null or the parsed object');
+                    //TODO: add test for parsed data when it will be available
+                });
+            })
+            .init()
+            .render($container);
+
+    });
 });

--- a/test/runner/api/test.js
+++ b/test/runner/api/test.js
@@ -741,28 +741,37 @@ define(['jquery', 'lodash', 'taoItems/runner/api/itemRunner', 'test/taoItems/run
     });
 
 
+    QUnit.module('ItemRunner getApipData', {
+        afterEach: function(assert) {
+            //reset the providers
+            delete itemRunner.providers;
+        }
+    });
+
     QUnit.test('getApipData', function(assert) {
-        assert.expect(1);
+        var ready = assert.async();
+        var $container;
+
+        assert.expect(2);
 
         $container = $('#item-container');
         assert.equal($container.length, 1, 'the item container exists');
 
         itemRunner.register('dummyProvider', dummyProvider);
 
-        itemRunner('dummyProvider', {
+        let runner = itemRunner('dummyProvider', {
             type: 'number',
             value: 0
-        })
-            .on('render', function() {
-                this.renderFeedbacks({"f":'f'}, ["f"], function(renderingQueue) {
-                    var apipData = itemRunner.getApipData();
-                    var apipDataIsApplicable = _.isNull(apipData) || _.isPlainObject(apipData);
-                    assert.ok(apipDataIsApplicable, 'getApipData returns a null or the parsed object');
-                    //TODO: add test for parsed data when it will be available
-                });
-            })
-            .init()
-            .render($container);
+        });
+        runner.on('render', function() {
+            var apipData = runner.getApipData();
+            var apipDataIsApplicable = _.isNull(apipData) || _.isPlainObject(apipData);
+            assert.ok(apipDataIsApplicable, 'getApipData returns a null or the parsed object');
+            // TODO: add test for parsed data when it will be available
 
+            ready();
+        })
+        .init()
+        .render($container);
     });
 });

--- a/test/runner/provider/dummyProvider.js
+++ b/test/runner/provider/dummyProvider.js
@@ -90,7 +90,7 @@ define(['lodash'], function(_) {
         },
 
         getApipData: function getApipData() {
-            return this._item.getApipAccessibility();
+            return this._item && _.isFunction(this._item.getApipAccessibility) && this._item.getApipAccessibility() || null;
         }
     };
 

--- a/test/runner/provider/dummyProvider.js
+++ b/test/runner/provider/dummyProvider.js
@@ -87,6 +87,10 @@ define(['lodash'], function(_) {
             });
 
             done(renderingQueue);
+        },
+
+        getApipData: function getApipData() {
+            return this._item.getApipAccessibility();
         }
     };
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9637
Acces the data about APIP the content and related media files

Steps to reproduce
login to prepared delivery and run test with any enabled tool plugin (for example, highlighter), set breakpoint inside any mathod executed after test loading and check data availability in console:
> testRunner.itemRunner.getApipData();

method must return null or object with Apip data if it presented in test data
#### Dependencies
Companion PR :
 - [ ] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/34