### PR TITLE
add itemRunner method getData

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "displayName": "TAO Item Runner",
     "description": "TAO Item Runner modules",
     "files": [

--- a/src/runner/README.md
+++ b/src/runner/README.md
@@ -49,6 +49,7 @@ It works in 2 steps:
 |    setState(Object state) : ItemRunner        +------------------->  setState(Object state) : void              |
 |    getResponses() : Array                     +------------------->  getResponses() : Array                     |
 |    clear() : ItemRunner                       +------------------->  clear() : void                             |
+|    getData() : Object                         +------------------->  getData() : Object                         |
 |                                                  |               |                                              |
 |    on(event,Func handler) : ItemRunner           |               |                                              |
 |    off(event) : ItemRunner                       |               |                                              |

--- a/src/runner/api/itemRunner.js
+++ b/src/runner/api/itemRunner.js
@@ -390,6 +390,16 @@ var itemRunnerFactory = function itemRunnerFactory(providerName, data, options) 
             return this;
         },
 
+
+        /**
+         * Get the item data.
+         *
+         * @returns {Object} the item's data
+         */
+        getData: function() {
+            return data;
+        },
+
         /**
          * Get the responses of the running item.
          *

--- a/test/runner/api/test.js
+++ b/test/runner/api/test.js
@@ -739,4 +739,27 @@ define(['jquery', 'lodash', 'taoItems/runner/api/itemRunner', 'test/taoItems/run
             .init()
             .render($container);
     });
+
+    QUnit.test('access item data', function(assert) {
+        var ready = assert.async();
+        var dummyData = {
+            alpha: 1,
+            beta: 'sample string',
+            gamma: {
+                delta: 'string 2',
+                epsilon: 'string 2',
+            }
+        };
+
+        assert.expect(1);
+
+        itemRunner.register('dummyProvider', dummyProvider);
+
+        itemRunner('dummyProvider', dummyData)
+            .on('init', function() {
+                assert.deepEqual(this.getData(), dummyData, 'getData() returns expected data');
+                ready();
+            })
+            .init();
+    });
 });

--- a/test/runner/provider/dummyProvider.js
+++ b/test/runner/provider/dummyProvider.js
@@ -67,6 +67,10 @@ define(['lodash'], function(_) {
             }
         },
 
+        getData: function() {
+            return this._data;
+        },
+
         getResponses: function() {
             var responses = [];
             var input = this.container.querySelector('input');


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9637
Acces the data about APIP the content and related media files

#### Steps to reproduce
prepare TAO instance, go to taoItems/views/package.json and replace current depencies
`  "dependencies": {
    "@oat-sa/tao-item-runner": "0.3.1"
  }`
with this branch:
`  "dependencies": {
    "@oat-sa/tao-item-runner": "github:oat-sa/tao-item-runner-fe#feauture/TAO-9637-access-apip-data"
  }`

login to prepared delivery and run test with any enabled tool plugin (for example, highlighter), set breakpoint inside any method executed after test loading and check data availability in console:
> testRunner.itemRunner.getData().apipAccessibility

or if testRunner variable unavailable:
>this.getTestRunner().itemRunner.getData().apipAccessibility

method must return null or object with Apip data if it presented in test data

#### Dependencies
Requires : nothing
