### PR TITLE
Fix/nex 1100/closed item should be able to suspend resume

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "displayName": "TAO Item Runner",
     "description": "TAO Item Runner modules",
     "files": [

--- a/src/runner/api/itemRunner.js
+++ b/src/runner/api/itemRunner.js
@@ -435,7 +435,7 @@ const itemRunnerFactory = function itemRunnerFactory(providerName, data = {}, op
          * @returns {Promise}
          */
         suspend() {
-            if (!suspended && !closed && flow.render.done && typeof provider.suspend === 'function') {
+            if (!suspended && flow.render.done && typeof provider.suspend === 'function') {
                 return provider.suspend.call(this).then(result => {
                     suspended = true;
                     return result;
@@ -460,14 +460,13 @@ const itemRunnerFactory = function itemRunnerFactory(providerName, data = {}, op
 
         /**
          * Call the provider's resume method.
-         * We can resume a previously suspended or closed item.
+         * We can resume a previously suspended item.
          * @returns {Promise}
          */
         resume() {
-            if ( (suspended || closed) && flow.render.done && typeof provider.resume === 'function') {
+            if (suspended && flow.render.done && typeof provider.resume === 'function') {
                 return provider.resume.call(this).then(result => {
                     suspended = false;
-                    closed = false;
                     return result;
                 });
             }


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/NEX-1100

`closed` and `suspended` state don't have any relation with each other. We should be able to suspend closed item; and resuming item should keep its closed state.

How to test:
apply in tao-item-runner-qtnui-fe & tao-test-runner-qtnui-fe and see that issue with opening overview on `remainingAttempts=0` item works correctly

