### PR TITLE
Fix/NEX-1100/Fix suspend conditional; update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ typings/
 .next
 
 dist
+
+# IDEs
+.vscode/
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "displayName": "TAO Item Runner",
     "description": "TAO Item Runner modules",
     "files": [

--- a/src/runner/api/itemRunner.js
+++ b/src/runner/api/itemRunner.js
@@ -435,7 +435,7 @@ const itemRunnerFactory = function itemRunnerFactory(providerName, data = {}, op
          * @returns {Promise}
          */
         suspend() {
-            if (!suspended && !closed && flow.render.done && typeof provider.suspend === 'function') {
+            if (!suspended && flow.render.done && typeof provider.suspend === 'function') {
                 return provider.suspend.call(this).then(result => {
                     suspended = true;
                     return result;


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/NEX-1100

Used in https://github.com/oat-sa/tao-test-runner-qtinui-fe/pull/82
Fixes this:
in '_submission restrictions_' preset, go to second item which has `remainingAttempts=0`   -> open/close overview -> open/close overview again -> transparent overlay is lost and item is editable
also, when you open overview, this item is still in DOM. It shouldn't be there.

In test-runner, item-runner states are used like this:
- remainingAttempts=0 -> disable item for editing -> 'closed' item-runner state
- show overview -> remove item from DOM -> 'suspended' item-runner state

**Changes**
Removed `closed` checking during suspending

How to test:
apply in item-runner https://github.com/oat-sa/tao-item-runner-qtinui-fe/pull/86 & test-runner https://github.com/oat-sa/tao-test-runner-qtinui-fe/pull/82 and check that overview issue is fixed