### PR TITLE
Fix [CON-203] - Color of arrowheads does not match with color of lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -433,18 +433,18 @@
             }
         },
         "@oat-sa/tao-core-libs": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.4.2.tgz",
-            "integrity": "sha512-XZhhEtGsrEctcr4ZEuTop1N96IRV8iWNTA2Ffvk83n7GDqSYZpLePkFK1VFxPKc1HlLEoXzx+YLQotq4UJQjvQ==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.4.3.tgz",
+            "integrity": "sha512-6H4B5ETIWK011gJIPNxOMP2xIdWLNcTpDRsQvLuHO/716KbGG5PCAFCgQwdhmyIBAx9ApUeTF2ee0Xn6Ds0FAA==",
             "dev": true
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.4.1.tgz",
-            "integrity": "sha512-apK+0tWKLVCN4Ezb6RGnPLOLptSZRclN4cGVpIBz5yfDgv6PGdyvXhC74OhlpTOx6+R0UlJQ3qrMyXKxqSZf6w==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.8.1.tgz",
+            "integrity": "sha512-SlfRorpBkNJPRN3S9wDTk5dPdfaCmEEr4gSvM1XaQYghJlYjsKrDFu63p4jfqwO8JHk9zSHWFg605de8DBRRCw==",
             "dev": true,
             "requires": {
-                "fastestsmallesttextencoderdecoder": "^1.0.14",
+                "fastestsmallesttextencoderdecoder": "1.0.14",
                 "idb-wrapper": "1.7.0",
                 "webcrypto-shim": "0.1.4"
             }
@@ -1623,9 +1623,9 @@
             "dev": true
         },
         "fastestsmallesttextencoderdecoder": {
-            "version": "1.0.22",
-            "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-            "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.14.tgz",
+            "integrity": "sha512-ov+uDh4DMZHpZvcGwlCb9tfntaHwRI7SK+/6XkdXhksZLJcMoTJ20FZx3GvujnsGjMvJVQ71LkduEUEPwX1BvQ==",
             "dev": true
         },
         "fd-slicer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "displayName": "TAO Item Runner",
     "description": "TAO Item Runner modules",
     "files": [
@@ -43,8 +43,8 @@
         "@oat-sa/expr-eval": "1.3.0",
         "@oat-sa/prettier-config": "^0.1.1",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
-        "@oat-sa/tao-core-libs": "^0.4.2",
-        "@oat-sa/tao-core-sdk": "^1.4.1",
+        "@oat-sa/tao-core-libs": "^0.4.3",
+        "@oat-sa/tao-core-sdk": "^1.8.1",
         "@oat-sa/tao-qunit-testrunner": "^1.0.3",
         "@rollup/plugin-alias": "^3.1.1",
         "async": "0.2.10",


### PR DESCRIPTION
**Issue**

https://oat-sa.atlassian.net/browse/CON-203

**Related work**

https://github.com/oat-sa/extension-tao-itemqti/issues/1577

**Description**

The color of all arrowheads (including axis arrowheads) changes, when we change the current line or add new. So, it will always inherit the color from the last path created with the arrow-end/ arrow-start attribute set.
 
![imagen](https://user-images.githubusercontent.com/34692207/104584984-aed6dd00-5663-11eb-9173-732e4fc5c82c.png)

The full description of [issue](https://github.com/oat-sa/extension-tao-itemqti)/issues/1577

Also, it looks like the PCI settings are broken on the construct side. When trying to open Lines options an error pops up in the console.

![imagen](https://user-images.githubusercontent.com/34692207/104585059-ca41e800-5663-11eb-939c-19309c432365.png)

**AC**

- [x] Fix arrow head color
- [ ] Fix error in console of PCI settings