### PR TITLE
Add options accessors

### DIFF
--- a/src/runner/api/itemRunner.js
+++ b/src/runner/api/itemRunner.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2020 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2014-2021 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
  *
  */
 
@@ -401,6 +401,28 @@ const itemRunnerFactory = function itemRunnerFactory(providerName, data = {}, op
             data = itemData;
             if (typeof provider.setData === 'function') {
                 return provider.setData.call(this, itemData);
+            }
+            return Promise.resolve();
+        },
+
+        /**
+         * Get the item runner options.
+         *
+         * @returns {Object} the item rendering options
+         */
+        getOptions() {
+            return this.options;
+        },
+
+        /**
+         * Replaces item runner's options.
+         * @param {Object} newOptions - the options to set
+         * @returns {Promise}
+         */
+        setOptions(newOptions = {}) {
+            this.options = newOptions;
+            if (typeof provider.setOptions === 'function') {
+                return provider.setOptions.call(this, this.options);
             }
             return Promise.resolve();
         },

--- a/test/runner/api/test.js
+++ b/test/runner/api/test.js
@@ -1038,7 +1038,6 @@ define(['jquery', 'taoItems/runner/api/itemRunner', 'test/taoItems/runner/provid
             Object.assign(
                 {
                     setOptions(receivedOptions) {
-                        console.log(receivedOptions);
                         assert.deepEqual(receivedOptions, newOptions, 'the provider receives the updated options');
                         return Promise.resolve();
                     }

--- a/test/runner/api/test.js
+++ b/test/runner/api/test.js
@@ -165,6 +165,9 @@ define(['jquery', 'taoItems/runner/api/itemRunner', 'test/taoItems/runner/provid
             .init();
     });
 
+
+
+
     QUnit.module('ItemRunner render', {
         afterEach() {
             //reset the providers
@@ -683,15 +686,17 @@ define(['jquery', 'taoItems/runner/api/itemRunner', 'test/taoItems/runner/provid
             value: 0
         })
             .on('render', function () {
-                this.renderFeedbacks({ f1: 'feedback1', f2: 'feedback2', f3: 'feedback3' }, ['f2'], function (
-                    renderingQueue
-                ) {
-                    assert.ok(renderingQueue instanceof Array, 'renderingQueue is an array');
-                    assert.equal(renderingQueue.length, 1, 'renderingQueue contains one entry');
-                    assert.equal(renderingQueue[0], 'feedback2', 'renderingQueue contains selected entry');
+                this.renderFeedbacks(
+                    { f1: 'feedback1', f2: 'feedback2', f3: 'feedback3' },
+                    ['f2'],
+                    function (renderingQueue) {
+                        assert.ok(renderingQueue instanceof Array, 'renderingQueue is an array');
+                        assert.equal(renderingQueue.length, 1, 'renderingQueue contains one entry');
+                        assert.equal(renderingQueue[0], 'feedback2', 'renderingQueue contains selected entry');
 
-                    ready();
-                });
+                        ready();
+                    }
+                );
             })
             .init()
             .render($container);
@@ -872,7 +877,6 @@ define(['jquery', 'taoItems/runner/api/itemRunner', 'test/taoItems/runner/provid
             .render($container);
     });
 
-
     QUnit.test('Close has no effect before rendering', assert => {
         const ready = assert.async();
         assert.expect(2);
@@ -982,5 +986,76 @@ define(['jquery', 'taoItems/runner/api/itemRunner', 'test/taoItems/runner/provid
             })
             .init()
             .render($container);
+    });
+
+    QUnit.test('get item runner options', assert => {
+        const ready = assert.async();
+        const options = {
+            settings: {
+                muted: true,
+                baseVolume: 75
+            }
+        };
+
+        assert.expect(1);
+
+        itemRunner.register('dummyProvider', dummyProvider);
+
+        itemRunner('dummyProvider', {}, options)
+            .on('init', function () {
+                assert.deepEqual(this.getOptions(), options, 'the options are correct');
+                ready();
+            })
+            .init();
+    });
+
+    QUnit.module('ItemRunner options', {
+        afterEach() {
+            //reset the provides
+            itemRunner.providers = noop;
+        }
+    });
+
+    QUnit.test('update item runner options', assert => {
+        const ready = assert.async();
+        const initialOptions = {
+            settings: {
+                muted: true,
+                baseVolume: 75
+            }
+        };
+        const newOptions = {
+            settings: {
+                muted: false,
+                baseVolume: 50
+            }
+        };
+
+        assert.expect(3);
+
+        itemRunner.register(
+            'dummyProvider',
+            Object.assign(
+                {
+                    setOptions(receivedOptions) {
+                        console.log(receivedOptions);
+                        assert.deepEqual(receivedOptions, newOptions, 'the provider receives the updated options');
+                        return Promise.resolve();
+                    }
+                },
+                dummyProvider
+            )
+        );
+
+        itemRunner('dummyProvider', {}, initialOptions)
+            .on('init', function () {
+                assert.deepEqual(this.getOptions(), initialOptions, 'initial options are correct');
+
+                this.setOptions(newOptions).then(() => {
+                    assert.deepEqual(this.getOptions(), newOptions, 'updated options are correct');
+                    ready();
+                });
+            })
+            .init();
     });
 });


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TRN-720

 - Add accessors for the item runner's `options`. The provider can implement the setter optionally.  This will be useful to update the settings while the item runner is running.

 Requires: 
 - [x] https://github.com/oat-sa/tao-item-runner-fe/pull/38

Companion PRs:
 - [ ] https://github.com/oat-sa/tao-item-runner-qtinui-fe/pull/389
 - [ ] https://github.com/oat-sa/tao-test-runner-qtinui-fe/pull/273

How to test:
 - [ ] run the unit tests
 - [ ] check with companion PRs 