### PR TITLE
Update raphael to 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1610,9 +1610,10 @@
             "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
             "dev": true
         },
-        "eve": {
-            "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-            "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
+        "eve-raphael": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
+            "integrity": "sha1-F8dUt5K+7z+maE15z1pHxjxM2jA=",
             "dev": true
         },
         "extract-zip": {
@@ -3277,12 +3278,12 @@
             "dev": true
         },
         "raphael": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.1.4.tgz",
-            "integrity": "sha1-sJymZK0Ei4FLsv9dTR51g4yrnJc=",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.3.0.tgz",
+            "integrity": "sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==",
             "dev": true,
             "requires": {
-                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+                "eve-raphael": "0.5.0"
             }
         },
         "raw-body": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "prettier": "^2.4.1",
         "promise-limit": "^2.7.0",
         "qunit": "^2.17.2",
-        "raphael": "2.1.4",
+        "raphael": "2.3.0",
         "require-css": "^0.1.10",
         "rollup": "^2.47.0",
         "rollup-plugin-istanbul": "^3.0.0",


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-3287

 - update rahpael to 2.3.0 in order to get rid of the subdependency to `eve` using `git://`